### PR TITLE
Move schemas to own package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ yarn.lock
 .vscode
 .mypy_cache
 *.code-workspace
+yarn-error.log
 
 packages/**/lib
 packages/**/build

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@jupyterlab/buildutils": "^1.0.0",
+    "@jupyterlab/buildutils": "^2.0.0-rc.0",
     "lerna": "^3.19.0"
   }
 }

--- a/packages/dummystore/package.json
+++ b/packages/dummystore/package.json
@@ -45,7 +45,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.2",
     "rimraf": "^2.5.2",
-    "typescript": "~3.6.4",
+    "typescript": "~3.7.5",
     "webpack": "^4.0.0",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/jupyterschemas/package.json
+++ b/packages/jupyterschemas/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "jupyterschemas",
+  "version": "0.1.0",
+  "description": "Schemas for the Jupyter data model",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib/"
+  },
+  "files": [
+    "lib/*.d.ts",
+    "lib/*.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jupyterlab/rtc.git"
+  },
+  "keywords": [
+    "lumino",
+    "datastore"
+  ],
+  "author": "JupyterLab contributors",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/rtc/issues"
+  },
+  "homepage": "https://github.com/jupyterlab/rtc#readme",
+  "dependencies": {
+    "@lumino/coreutils": "^1.4.1",
+    "@lumino/datastore": "^0.8.3",
+    "@jupyterlab/nbformat": "^2.0.0-rc.0"
+  },
+  "devDependencies": {
+    "rimraf": "^2.5.2",
+    "typescript": "~3.7.5"
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rimraf lib && rimraf *.tsbuildinfo",
+    "watch": "tsc --build --watch"
+  }
+}

--- a/packages/jupyterschemas/src/index.js
+++ b/packages/jupyterschemas/src/index.js
@@ -1,0 +1,105 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var datastore_1 = require("@lumino/datastore");
+// Q: Do we add "refrefsh xxx" method?
+// N: Yes.
+// Q: Do we fully normalize into tables?
+// A: No, only enough to allow collaboration.
+//    So anything that might need to be merged should be its own field.
+//    Also, we want to minimize the size of diffs.
+// Q: Where should selections go?
+// A: ?
+// Q: Should output refer to cells or vice versa?
+// A: ?
+// Q: Why does this have to proxy all iopub messages?
+// A: So that it can keep kernel state up to date: https://jupyter-client.readthedocs.io/en/stable/messaging.html#request-reply
+// Q: Should we use REST or websockets?
+// A: https://www.cncf.io/blog/2018/04/12/crcp-the-curiously-reoccurring-communications-pattern/
+// https://github.com/wamp-proto/wamp-proto
+// https://nats.io/blog/resgate_nats/
+exports.TABLES = {
+    kernelspecs: {
+        // have all as one field instead of many fields, because won't ever change this
+        // so having by-field diffs isn't important
+        kernelspec: datastore_1.Fields.Register({ value: null })
+    },
+    status: {
+        // Table with only one row
+        started: datastore_1.Fields.String(),
+        last_activity: datastore_1.Fields.String(),
+        connections: datastore_1.Fields.Number(),
+        kernels: datastore_1.Fields.Number()
+    },
+    terminals: {
+        name: datastore_1.Fields.String()
+    },
+    kernels: {
+        name: datastore_1.Fields.String(),
+        last_activity: datastore_1.Fields.String(),
+        connections: datastore_1.Fields.Number(),
+        execution_state: datastore_1.Fields.Number()
+    },
+    sessions: {
+        path: datastore_1.Fields.String(),
+        name: datastore_1.Fields.String(),
+        type: datastore_1.Fields.String(),
+        kernel_id: datastore_1.Fields.String()
+    },
+    contents: {
+        name: datastore_1.Fields.String(),
+        path: datastore_1.Fields.String(),
+        type: datastore_1.Fields.Register({
+            value: null
+        }),
+        writeable: datastore_1.Fields.Boolean(),
+        created: datastore_1.Fields.String(),
+        last_modified: datastore_1.Fields.String(),
+        size: datastore_1.Fields.Register({
+            value: null
+        }),
+        mimetype: datastore_1.Fields.Register({
+            value: null
+        }),
+        format: datastore_1.Fields.Register({
+            value: null
+        })
+    },
+    text_content: {
+        // Should relation be to content or from this one?
+        content_id: datastore_1.Fields.String(),
+        content: datastore_1.Fields.Text()
+    },
+    base64_content: {
+        content_id: datastore_1.Fields.String(),
+        content: datastore_1.Fields.String()
+    },
+    folders: {
+        content_id: datastore_1.Fields.String(),
+        content: datastore_1.Fields.List()
+    },
+    notebooks: {
+        content_id: datastore_1.Fields.String(),
+        nbformat: datastore_1.Fields.Number(),
+        nbformatMinor: datastore_1.Fields.Number(),
+        cells: datastore_1.Fields.List(),
+        metadata: datastore_1.Fields.Map()
+    },
+    cells: {
+        attachments: datastore_1.Fields.Map(),
+        executionCount: datastore_1.Fields.Register({ value: null }),
+        metadata: datastore_1.Fields.Map(),
+        mimeType: datastore_1.Fields.String(),
+        outputs: datastore_1.Fields.List(),
+        text: datastore_1.Fields.Text(),
+        trusted: datastore_1.Fields.Boolean(),
+        type: datastore_1.Fields.Register({ value: "code" })
+    },
+    outputs: {
+        trusted: datastore_1.Fields.Boolean(),
+        type: datastore_1.Fields.String(),
+        executionCount: datastore_1.Fields.Register({ value: null }),
+        data: datastore_1.Fields.Register({ value: {} }),
+        metadata: datastore_1.Fields.Register({ value: {} }),
+        raw: datastore_1.Fields.Register({ value: {} })
+    }
+};

--- a/packages/jupyterschemas/src/index.ts
+++ b/packages/jupyterschemas/src/index.ts
@@ -1,6 +1,6 @@
-import { AnyField, Fields } from "@phosphor/datastore";
-import { ReadonlyJSONObject, ReadonlyJSONValue } from "@phosphor/coreutils";
-import { nbformat } from "@jupyterlab/coreutils";
+import { AnyField, Fields } from "@lumino/datastore";
+import { ReadonlyJSONObject, ReadonlyJSONValue } from "@lumino/coreutils";
+import * as nbformat from "@jupyterlab/nbformat";
 
 // Q: Do we add "refrefsh xxx" method?
 // N: Yes.
@@ -12,8 +12,6 @@ import { nbformat } from "@jupyterlab/coreutils";
 
 // Q: Where should selections go?
 // A: ?
-
-
 
 // Q: Should output refer to cells or vice versa?
 // A: ?
@@ -110,7 +108,7 @@ export const TABLES: { [id: string]: { [name: string]: AnyField } } = {
     metadata: Fields.Map<ReadonlyJSONValue>()
   },
   cells: {
-    attachments: Fields.Map<nbformat.IMimeBundle>(),
+    attachments: Fields.Map<ReadonlyJSONObject>(),
     executionCount: Fields.Register<nbformat.ExecutionCount>({ value: null }),
     metadata: Fields.Map<ReadonlyJSONValue>(),
     mimeType: Fields.String(),

--- a/packages/jupyterschemas/tsconfig.json
+++ b/packages/jupyterschemas/tsconfig.json
@@ -1,0 +1,66 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
This moves the start of the Jupyter datastore schemas to its own package

* Upgrade Typescript and JupyterLab deps
* Add new package
* Move existing schemas to file
* Update with JLab 2.0 import changes