### PR TITLE
Abstract out to base tsconfig

### DIFF
--- a/packages/rtc-node/tsconfig.json
+++ b/packages/rtc-node/tsconfig.json
@@ -1,16 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
     "outDir": "lib",
-    "rootDir": "src",
-    "strict": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
-    "jsx": "react",
-    "forceConsistentCasingInFileNames": true,
-    "composite": true
+    "rootDir": "src"
   },
-  "include": ["src/*"]
+  "include": ["src"]
 }

--- a/packages/rtc-relay/tsconfig.json
+++ b/packages/rtc-relay/tsconfig.json
@@ -1,15 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
     "outDir": "lib",
-    "rootDir": "src",
-    "strict": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
-    "forceConsistentCasingInFileNames": true,
-    "composite": true
+    "rootDir": "src"
   },
-  "include": ["src/*"]
+  "include": ["src"]
 }

--- a/packages/rtc-todo-example/tsconfig.json
+++ b/packages/rtc-todo-example/tsconfig.json
@@ -1,33 +1,14 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es6",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "outDir": "lib",
-    "rootDir": "src",
-    "jsx": "react",
     "noEmit": true,
-    "sourceMap": true
+    "outDir": "lib",
+    "rootDir": "src"
   },
   "references": [
     {
       "path": "../rtc-node"
     }
   ],
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "jsx": "react",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "composite": true
+  }
+}


### PR DESCRIPTION
This PR makes it easier to add new TS packages by abstracting out most of the tsconfig to a base one.

Note that the path config options can not be abstracted or else they will be relative to the root directory instead of the package directory, so unfortunately we have to duplicate these in each package.