### PR TITLE
Docs: Link to reddit + JupyterLab port

### DIFF
--- a/docs/source/about/libraries.md
+++ b/docs/source/about/libraries.md
@@ -8,6 +8,10 @@ CRDT Implementation by JupyterLab.
 
 - <https://github.com/jupyterlab/lumino/tree/master/packages/datastore>
 
+Used by.
+
+- [interactive-dashboard-editor](https://github.com/jupytercalpoly/jupyterlab-interactive-dashboard-editor)
+
 ## Y.js
 
 CRDT Implementation.

--- a/docs/source/about/user-stories.md
+++ b/docs/source/about/user-stories.md
@@ -2,7 +2,12 @@
 
 _During our first meeting we collected a few different user stories. We are looking to more elaborated and structured stories that should be considered._
 
-There is a recent paper published by acm.org on Data Scientist RTC needs we should look at[^f1].
+We list here source for inspiration and discussion:
+
+- [Reddit discussion on multi user collaborative notebook](https://www.reddit.com/r/datascience/comments/i5hj2o/multi_user_collaborative_notebook)
+- Paper published by acm.org in November 2019 on Data Scientist RTC [^f1].
+
+The following sections surface topics we have discussed.
 
 ## Shared Kernel
 

--- a/docs/source/developer/architecture.md
+++ b/docs/source/developer/architecture.md
@@ -29,7 +29,23 @@ It is currently in the planning stage, but eventually we see this repo containin
 - `src/rtc_relay_jupyter_extension`: Jupyter Server Extension for `packages/rtc-relay`
 - `packages/jupyterlab-rtc-client`: `packages/rtc-client` that connects over `src/rtc_relay_jupyter_extension`.
 
-## State
+## Integration in JupyterLab
+
+This work is tracked in [jupyterlab/rtc#27](https://github.com/jupyterlab/rtc/issues/27).
+
+We had two branches for JupyterLab 1.0.3 and Phosphor:
+
+- https://github.com/vidartf/jupyterlab/tree/rtc
+- https://github.com/vidartf/phosphor/commits/feature-tables3-extras
+
+You can try them with `docker run -p 8888:8888 ellisonbg/jupyterlab-rtc start.sh jupyter lab --dev-mode --no-browser` (Dockerfile for this lives in https://github.com/ellisonbg/jupyterlab-rtc)
+
+We are now porting those changes to latest JupyterLab and Lumino master.
+
+- https://github.com/datalayer-contrib/jupyterlab/tree/rtc
+- https://github.com/datalayer-contrib/jupyterlab-lumino/tree/rtc
+
+## Distributed State
 
 We may need to introduce a global distributed state management `a-la-redux`. See the following repositories for inspiration:
 

--- a/docs/source/developer/design.md
+++ b/docs/source/developer/design.md
@@ -5,7 +5,7 @@
 The goal of this repo is to prototype a data model to support simultaneous distributed
 editing in Jupyter.
 
-Fundamentally, it's about taking the **existing** concepts[^f1] provided by Jupyter server and creating a real time data model on top of them.
+Fundamentally, it's about taking the **existing** concepts[^f1] provided by Jupyter Server and creating a real time data model on top of them.
 
 This would help provide a Google Docs like editing experience in Jupyter editors by
 allowing multiple simultaneous users to edit a document at once.
@@ -21,6 +21,8 @@ This will happen in a number of different layers, added to this monorepo:
 2. Middle: Friendly real time datastore using this with React integration
 3. Higher level/Jupyter: Support for editing all data in Jupyter server
 4. Jupyter clients: JupyterLab integration, Spyder integration, nteract integration (examples)
+
+The definition of those layers is still in progress. You can discuss this on [jupyterlab/rtc#61](https://github.com/jupyterlab/rtc/issues/61).
 
 ## Non Goals
 


### PR DESCRIPTION
Implement suggestion of https://github.com/jupyterlab/rtc/issues/65 to add a link to the current reddit discussion on the RTD site.

This also add a section on the current work for JupyterLab port.