### PR TITLE
Enforce rxjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {},
   "resolutions": {
-    "lodash": "4.17.15"
+    "lodash": "4.17.15",
+    "rxjs": "6.6.0"
   },
   "devDependencies": {
     "@jupyterlab/buildutils": "^2.0.0-rc.0",


### PR DESCRIPTION
This ensures same version across all lerna packages by adding the following to the root package.json

```
   "resolutions": {
-    "lodash": "4.17.15"
+    "lodash": "4.17.15",
+    "rxjs": "6.6.0"
   },
```

This fixes recent CI failures we have seen e.g. on https://github.com/jupyterlab/rtc/pull/69/checks?check_run_id=988196089

```
##[error]packages/rtc-node/src/react.tsx(50,45): error TS2769: No overload matches this call.
  Overload 1 of 4, '(input$: Observable<Datastore>): Datastore | undefined', gave the following error.
    Argument of type 'import("/home/runner/work/rtc/rtc/packages/rtc-node/node_modules/rxjs/internal/Observable").Observable<import("/home/runner/work/rtc/rtc/node_modules/@lumino/datastore/types/datastore").Datastore>' is not assignable to parameter of type 'import("/home/runner/work/rtc/rtc/node_modules/rxjs/internal/Observable").Observable<import("/home/runner/work/rtc/rtc/node_modules/@lumino/datastore/types/datastore").Datastore>'.
      Types of property 'source' are incompatible.
        Type 'import("/home/runner/work/rtc/rtc/packages/rtc-node/node_modules/rxjs/internal/Observable").Observable<any>' is not assignable to type 'import("/home/runner/work/rtc/rtc/node_modules/rxjs/internal/Observable").Observable<any>'.
  Overload 2 of 4, '(init: (input$: Observable<unknown>) => Observable<unknown>): [unknown, (input: unknown) => void]', gave the following error.
    Argument of type 'Observable<Datastore>' is not assignable to parameter of type '(input$: Observable<unknown>) => Observable<unknown>'.
      Type 'Observable<Datastore>' provides no match for the signature '(input$: Observable<unknown>): Observable<unknown>'.
##[error]packages/rtc-node/src/react.tsx(74,29): error TS2769: No overload matches this call.
  Overload 1 of 4, '(input$: Observable<T>, initialState: T | (() => T)): T', gave the following error.
    Argument of type 'import("/home/runner/work/rtc/rtc/packages/rtc-node/node_modules/rxjs/internal/Observable").Observable<T>' is not assignable to parameter of type 'import("/home/runner/work/rtc/rtc/node_modules/rxjs/internal/Observable").Observable<T>'.
      The types of 'source.operator.call' are incompatible between these types.
        Type '(subscriber: import("/home/runner/work/rtc/rtc/packages/rtc-node/node_modules/rxjs/internal/Subscriber").Subscriber<any>, source: any) => import("/home/runner/work/rtc/rtc/packages/rtc-node/node_modules/rxjs/internal/types").TeardownLogic' is not assignable to type '(subscriber: import("/home/runner/work/rtc/rtc/node_modules/rxjs/internal/Subscriber").Subscriber<any>, source: any) => import("/home/runner/work/rtc/rtc/node_modules/rxjs/internal/types").TeardownLogic'.
          Types of parameters 'subscriber' and 'subscriber' are incompatible.
            Type 'import("/home/runner/work/rtc/rtc/node_modules/rxjs/internal/Subscriber").Subscriber<any>' is not assignable to type 'import("/home/runner/work/rtc/rtc/packages/rtc-node/node_modules/rxjs/internal/Subscriber").Subscriber<any>'.
```