### PR TITLE
More robust py deps for myst_parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,13 +50,12 @@ setup(
         # Note: This is only required for internal use
         "rtd": [
             "myst_parser",
-            "markdown-it-py~=0.4.5",
             "pyyaml",
             "docutils>=0.15",
-            "sphinx>=2,<3",
-            "sphinxcontrib-bibtex", 
-            "ipython", 
-            "sphinx-book-theme", 
+            "sphinx",
+            "sphinxcontrib-bibtex",
+            "ipython",
+            "sphinx-book-theme",
             "sphinx_tabs"
         ],
     },


### PR DESCRIPTION
More robust py deps for myst_parser (see also https://github.com/jupyterlab/benchmarks/pull/20 and https://github.com/jupyterlab/benchmarks/pull/21).