### PR TITLE
Disable declaration to allow build:tsc in the examples

### DIFF
--- a/examples/jupyter/tsconfig.json
+++ b/examples/jupyter/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "esnext",
+    "declaration": false,
     "isolatedModules": true
   },
   "include": [

--- a/examples/todo/tsconfig.json
+++ b/examples/todo/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "esnext",
+    "declaration": false,
     "isolatedModules": true
   },
   "include": [


### PR DESCRIPTION
This temporary disables `declaration` in `tsconfig.json` to allow `yarn build:tsc`.

I have opened https://github.com/jupyterlab/rtc/issues/85 as follow-up cc/ @saulshanabrook 

This will hopefully fix the CI.