### PR TITLE
Changes sent as list instead of one by one.

### DIFF
--- a/automerge/jupyter_rtc/handlers.py
+++ b/automerge/jupyter_rtc/handlers.py
@@ -59,9 +59,12 @@ class AutomergeRoom:
         self.automerge_backend = jrtcam.automerge.apply_change(
             self.automerge_backend, message)
 
+        payload = json.dumps([list(message)])
+        #print("DISPATCH PAYLOAD : ", payload)
+
         for ws in self.websockets:
             if ws != sender:
-                ws.write_message(message, binary=True)
+                ws.write_message(payload)
 
 
 class AutomergeWsHandler(WebSocketMixin, WebSocketHandler, ExtensionHandlerMixin, JupyterHandler):
@@ -82,9 +85,9 @@ class AutomergeWsHandler(WebSocketMixin, WebSocketHandler, ExtensionHandlerMixin
               shared_automerge_rooms[doc].automerge_backend)
 
         changes = shared_automerge_rooms[doc].get_changes()
-        for c in changes:
-            message = bytes(c)
-            self.write_message(message, binary=True)
+        payload = json.dumps(changes)
+        #print("OPEN PAYLOAD : ", payload)
+        self.write_message(payload)
 
     def on_message(self, message,  *args, **kwargs):
 
@@ -94,7 +97,7 @@ class AutomergeWsHandler(WebSocketMixin, WebSocketHandler, ExtensionHandlerMixin
                 f"WEIRD : on_message for {doc} not in shared_automerge_rooms")
             return
 
-        print(f"\nDEBUG message : {message}")
+        #print(f"\nDEBUG message : {message}")
 
         shared_automerge_rooms[doc].dispatch_message(message, sender=self)
 

--- a/automerge/jupyter_rtc/handlers.py
+++ b/automerge/jupyter_rtc/handlers.py
@@ -55,12 +55,11 @@ class AutomergeRoom:
 
     def dispatch_message(self, message, sender=None):
 
-        # TODO : forward the message to the automerge document
+        # Forward the message to the automerge document
         self.automerge_backend = jrtcam.automerge.apply_change(
             self.automerge_backend, message)
 
         payload = json.dumps([list(message)])
-        #print("DISPATCH PAYLOAD : ", payload)
 
         for ws in self.websockets:
             if ws != sender:
@@ -86,7 +85,6 @@ class AutomergeWsHandler(WebSocketMixin, WebSocketHandler, ExtensionHandlerMixin
 
         changes = shared_automerge_rooms[doc].get_changes()
         payload = json.dumps(changes)
-        #print("OPEN PAYLOAD : ", payload)
         self.write_message(payload)
 
     def on_message(self, message,  *args, **kwargs):
@@ -96,8 +94,6 @@ class AutomergeWsHandler(WebSocketMixin, WebSocketHandler, ExtensionHandlerMixin
             print(
                 f"WEIRD : on_message for {doc} not in shared_automerge_rooms")
             return
-
-        #print(f"\nDEBUG message : {message}")
 
         shared_automerge_rooms[doc].dispatch_message(message, sender=self)
 

--- a/automerge/packages/jupyterlab-rtc/src/AutomergeActions.ts
+++ b/automerge/packages/jupyterlab-rtc/src/AutomergeActions.ts
@@ -16,8 +16,13 @@ export const initDocumentText = (): Doc => {
   )
 }
 
-export const applyChanges = (doc: Doc, changes: Uint8Array[]) => {
-  return Automerge.applyChanges(doc, changes);
+export const applyChanges = (doc: Doc, changes: Array<Array<number>>): Doc => {
+
+  changes.forEach((chunk) => {
+    doc = Automerge.applyChanges(doc, [new Uint8Array(chunk)]);
+  });
+
+  return doc;
 }
 
 export const getChanges = (oldDoc: Doc, newDoc: Doc) => {

--- a/automerge/packages/jupyterlab-rtc/src/index.ts
+++ b/automerge/packages/jupyterlab-rtc/src/index.ts
@@ -71,7 +71,6 @@ class Rtc {
       this.ws.onmessage = (message: any) => {
         if (message.data) {
 
-          // const data = new Uint8Array(message.data);
           const data = JSON.parse(message.data);
           const changedDoc = applyChanges(this.rtcCell, data);
           this.rtcCell = changedDoc;
@@ -113,7 +112,6 @@ class Rtc {
       this.ws.onmessage = (message: any) => {
         if (message.data) {
 
-          // const data = new Uint8Array(message.data);
           const data = JSON.parse(message.data);
           const changedDoc = applyChanges(this.rtcEditor, data);
           this.rtcEditor = changedDoc;

--- a/automerge/packages/jupyterlab-rtc/src/index.ts
+++ b/automerge/packages/jupyterlab-rtc/src/index.ts
@@ -70,8 +70,10 @@ class Rtc {
       this.ws.binaryType = 'arraybuffer';
       this.ws.onmessage = (message: any) => {
         if (message.data) {
-          const data = new Uint8Array(message.data);
-          const changedDoc = applyChanges(this.rtcCell, [data]);
+
+          // const data = new Uint8Array(message.data);
+          const data = JSON.parse(message.data);
+          const changedDoc = applyChanges(this.rtcCell, data);
           this.rtcCell = changedDoc;
           const text = this.rtcCell.textArea.toString()
           if (this.cell.model.value.text !== text) {
@@ -110,8 +112,10 @@ class Rtc {
       this.ws.binaryType = 'arraybuffer';
       this.ws.onmessage = (message: any) => {
         if (message.data) {
-          const data = new Uint8Array(message.data);
-          const changedDoc = applyChanges(this.rtcEditor, [data]);
+
+          // const data = new Uint8Array(message.data);
+          const data = JSON.parse(message.data);
+          const changedDoc = applyChanges(this.rtcEditor, data);
           this.rtcEditor = changedDoc;
           const text = this.rtcEditor.textArea.toString()
           if (this.fileEditor.model.value.text !== text) {

--- a/automerge/packages/textarea/src/automerge/AutomergeTextArea.tsx
+++ b/automerge/packages/textarea/src/automerge/AutomergeTextArea.tsx
@@ -36,9 +36,15 @@ const AutomergeTextAreaPerf = (props: {docId: string}) => {
     // wsRef.current = new WebSocket('ws://localhost:8989/datalayer_rtc/proxy?port=4321&doc=automerge-room2');
     wsRef.current.binaryType = 'arraybuffer';
     wsRef.current.onmessage = (message: any) => {
+
       if (message.data) {
-        const data = new Uint8Array(message.data);
-        const changedDoc = applyChanges(docRef.current, [data]);
+
+        const data = JSON.parse(message.data);
+        var changedDoc = docRef.current;
+        data.forEach((chunk) => {
+          changedDoc = applyChanges(changedDoc, [new Uint8Array(Object.values(chunk))]);
+        });
+
         setDoc(changedDoc);
         console.log("changedDoc : ", changedDoc);
       }
@@ -53,7 +59,8 @@ const AutomergeTextAreaPerf = (props: {docId: string}) => {
     const newDoc = applyInput(doc, diff);
     setDoc(newDoc);
     const changes = getChanges(doc, newDoc);
-    wsRef.current.send((changes[0] as any));
+    var payload = JSON.stringify(changes);
+    wsRef.current.send((payload as any));
   }
 
   const handleShowHistory = () => {


### PR DESCRIPTION
Changes from Automerge are now sent as list of changes, instead of being sent one by one. 
Fixes the behavior when reloading the page : all changes are now applied at once.