### PR TITLE
Rust backend is now TextArea-specific + params + cleanup

### DIFF
--- a/automerge/jupyter_rtc/handlers.py
+++ b/automerge/jupyter_rtc/handlers.py
@@ -41,7 +41,7 @@ class AutomergeRoom:
 
         self.docname = doc
         self.websockets = []
-        self.automerge_backend = jrtcam.automerge.new_document()
+        self.automerge_backend = jrtcam.automerge.new_document("automerge-room", "Hello !")
         print("Room init, document : ", self.automerge_backend)
 
     def add_websocket(self, ws):

--- a/automerge/rust/jupyter_rtc_automerge/tests/test_jupyter_rtc_automerge.py
+++ b/automerge/rust/jupyter_rtc_automerge/tests/test_jupyter_rtc_automerge.py
@@ -2,7 +2,7 @@ import jupyter_rtc_automerge as jrtcam
 
 
 # serialized backend
-backend = jrtcam.automerge.new_document()
+backend = jrtcam.automerge.new_document("document id", "Document content. Hello !")
 
 changes = jrtcam.automerge.get_changes(backend)
 

--- a/automerge/rust/src/amtextarea.rs
+++ b/automerge/rust/src/amtextarea.rs
@@ -42,7 +42,7 @@ fn default_document(doc_id: &str, default_text: &str) -> automerge_backend::Back
     // the textArea key contains the content of the client-side text area
     let change = automerge_frontend::LocalChange::set(
         automerge_frontend::Path::root().key("textArea"),
-        automerge_frontend::Value::Text("Hello".chars().collect()),
+        automerge_frontend::Value::Text(default_text.chars().collect()),
     );
 
     let change_request = doc_frontend

--- a/automerge/rust/src/amtextarea.rs
+++ b/automerge/rust/src/amtextarea.rs
@@ -1,16 +1,10 @@
 // Python Wrappers
-use pyo3::conversion::FromPyObject;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
 use pyo3::wrap_pyfunction;
 // Automerge Libraries
 use automerge_backend;
 use automerge_frontend;
 use automerge_protocol;
-use log::{debug, info, LevelFilter};
-use simplelog::*;
-use std::any::Any;
-use std::collections::HashMap;
 
 fn default_document(doc_id: &str, default_text: &str) -> automerge_backend::Backend {
     let mut doc_backend = automerge_backend::Backend::init();
@@ -70,7 +64,7 @@ fn new_document(doc_id: &str, default_text: &str) -> std::vec::Vec<u8> {
 
 #[pyfunction]
 fn apply_change(doc: std::vec::Vec<u8>, change_data: std::vec::Vec<u8>) -> std::vec::Vec<u8> {
-    let mut backend = automerge_backend::Backend::load(doc)
+    let mut doc_backend = automerge_backend::Backend::load(doc)
         .and_then(|back| Ok(back))
         .unwrap();
 
@@ -78,29 +72,23 @@ fn apply_change(doc: std::vec::Vec<u8>, change_data: std::vec::Vec<u8>) -> std::
         .and_then(|c| Ok(c))
         .unwrap();
 
-    backend
+    doc_backend
         .apply_changes(vec![change])
         .and_then(|patch| Ok(patch))
         .unwrap();
 
-    let doc = backend.save().and_then(|data| Ok(data));
+    let doc_data = doc_backend.save().and_then(|data| Ok(data));
 
-    return doc.unwrap();
-}
-
-#[pyfunction]
-fn consume_notebook(nb: &PyDict) {
-    info!("the notebook model has been sent, {}", nb);
-    // let v: HashMap = nb.extract()?;
+    return doc_data.unwrap();
 }
 
 #[pyfunction]
 fn get_changes(doc: std::vec::Vec<u8>) -> std::vec::Vec<std::vec::Vec<u8>> {
-    let backend = automerge_backend::Backend::load(doc)
+    let doc_backend = automerge_backend::Backend::load(doc)
         .and_then(|back| Ok(back))
         .unwrap();
 
-    let changes = backend.get_changes(&[]);
+    let changes = doc_backend.get_changes(&[]);
 
     let mut changes_bytes: std::vec::Vec<std::vec::Vec<u8>> = std::vec::Vec::new();
 
@@ -115,6 +103,25 @@ pub fn init_submodule(module: &PyModule) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(new_document, module)?)?;
     module.add_function(wrap_pyfunction!(apply_change, module)?)?;
     module.add_function(wrap_pyfunction!(get_changes, module)?)?;
-    module.add_function(wrap_pyfunction!(consume_notebook, module)?)?;
     Ok(())
 }
+
+#[test]
+fn test_new_document() {
+
+    // Simple test over the critical path : create document, get changes.
+    
+    // apply_changes will have to be tested :
+    // - here, instanciating an automerge frontend and generating a patch of changes, and checking the document changed
+    // - through an automated UI test using a text area
+    
+    let doc_data = new_document("test_doc_id", "Test content");
+    let changes_data = get_changes(doc_data);
+    
+
+    // There must be two changes : one to set the doc id, one to set the content
+    assert_eq!( changes_data.len(), 2  );
+    
+    
+}
+

--- a/automerge/rust/src/lib.rs
+++ b/automerge/rust/src/lib.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 use log::{ LevelFilter};
 use simplelog::*;
 
-mod ambackend;
+mod amtextarea;
 
 
 // The main python module - jupyter_rtc_automerge
@@ -27,7 +27,7 @@ fn jupyter_rtc_automerge(py: Python, module: &PyModule) -> PyResult<()> {
     .unwrap();
 
     let submod = PyModule::new(py, "automerge")?;
-    ambackend::init_submodule(submod)?;
+    amtextarea::init_submodule(submod)?;
     module.add_submodule(submod)?;
     Ok(())
 }


### PR DESCRIPTION
- The backend is now specific to the TextArea demonstrator, that's why is has been renamed into `amtextarea.rs` (`am`  stands for automerge indeed)
- all variables referring to the document have been renamed into `doc` followed by a more specific hint about the format of the value : `doc_backend`, `doc_data` ...
- a first test has been added into `amtextarea.rs`. run it with `cargo test`.
- The JupyterLab Extension handler builds a textarea automerge backend, passing it its specific values for the doc_id and default_text : 
```python
 self.automerge_backend = jrtcam.automerge.new_document("automerge-room", "Hello !")
 ``` 

