### PR TITLE
RTC now uses latest-to-date Automerge version

### DIFF
--- a/automerge/Makefile
+++ b/automerge/Makefile
@@ -4,7 +4,7 @@ CONDA_ACTIVATE=source $$(conda info --base)/etc/profile.d/conda.sh ; conda activ
 CONDA_DEACTIVATE=source $$(conda info --base)/etc/profile.d/conda.sh ; conda deactivate
 CONDA_REMOVE=source $$(conda info --base)/etc/profile.d/conda.sh ; conda remove -y --all -n
 
-GITHUB_APP_CREDENTIALS=echo "export GITHUB_CLIENT_ID=YOUR_CLIENT_ID_HERE; export GITHUB_CLIENT_SECRET=YOUR_SECRET_HERE"
+GITHUB_APP_CREDENTIALS=export GITHUB_CLIENT_ID='YOUR_CLIENT_ID_HERE'; export GITHUB_CLIENT_SECRET='YOUR_SECRET_HERE'
 
 .PHONY: clean install
 

--- a/automerge/rust/Cargo.toml
+++ b/automerge/rust/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 
 [dependencies]
-automerge-backend = { git = "https://github.com/pierrotsmnrd/automerge-rs/", tag = "jupyter_rtc_0.0.1" }
-automerge-frontend = { git = "https://github.com/pierrotsmnrd/automerge-rs/", tag = "jupyter_rtc_0.0.1" }
-automerge-protocol = { git = "https://github.com/pierrotsmnrd/automerge-rs/", tag = "jupyter_rtc_0.0.1" }
+automerge-backend = { git = "https://github.com/pierrotsmnrd/automerge-rs/", tag = "jupyter_rtc_0.0.2" }
+automerge-frontend = { git = "https://github.com/pierrotsmnrd/automerge-rs/", tag = "jupyter_rtc_0.0.2" }
+automerge-protocol = { git = "https://github.com/pierrotsmnrd/automerge-rs/", tag = "jupyter_rtc_0.0.2" }
 
 log = "0.4.11"
 simplelog = "*"

--- a/automerge/rust/src/automerge_map.rs
+++ b/automerge/rust/src/automerge_map.rs
@@ -216,11 +216,12 @@ fn automerge_primivite_to_py<'p>(
         automerge_protocol::ScalarValue::Null => unsafe { &(py.from_owned_ptr(ffi::Py_None())) },
 
         // we're not supposed to store any of the following values in the backend
-        automerge_protocol::ScalarValue::Str(s) => PyString::new(py, "N/A"),
-        automerge_protocol::ScalarValue::Uint(ui) => PyString::new(py, "N/A"),
-        automerge_protocol::ScalarValue::F32(f) => PyString::new(py, "N/A"),
-        automerge_protocol::ScalarValue::Counter(c) => PyString::new(py, "N/A"),
-        automerge_protocol::ScalarValue::Timestamp(t) => PyString::new(py, "N/A"),
+        automerge_protocol::ScalarValue::Str(_) => PyString::new(py, "N/A"),
+        automerge_protocol::ScalarValue::Uint(u_) => PyString::new(py, "N/A"),
+        automerge_protocol::ScalarValue::F32(_) => PyString::new(py, "N/A"),
+        automerge_protocol::ScalarValue::Counter(_) => PyString::new(py, "N/A"),
+        automerge_protocol::ScalarValue::Timestamp(_) => PyString::new(py, "N/A"),
+        _ => unsafe { &(py.from_owned_ptr(ffi::Py_None())) },
     }
 }
 


### PR DESCRIPTION
RTC now uses the latest-to-date version of Automerge, tagged for our project as `jupyter_rtc_0.0.2` 
\+ impacts + fix typo + remove some warnings 